### PR TITLE
refactor: remove unnecessary className from portals

### DIFF
--- a/src/components/alert-dialog/alert-dialog.st.css
+++ b/src/components/alert-dialog/alert-dialog.st.css
@@ -7,8 +7,6 @@
     -st-states: open('[data-state="open"]'), closed('[data-state="closed"]');
 }
 
-.portal {}
-
 .overlay {
     -st-states: open('[data-state="open"]'), closed('[data-state="closed"]');
 }

--- a/src/components/alert-dialog/alert-dialog.tsx
+++ b/src/components/alert-dialog/alert-dialog.tsx
@@ -18,11 +18,7 @@ export const AlertDialogTrigger: typeof RadixAlertDialog.Trigger = React.forward
     }
 );
 
-export const AlertDialogPortal: React.FC<RadixAlertDialog.DialogPortalProps> = function Accordion(
-    props
-) {
-    return <RadixAlertDialog.Portal {...props} className={st(classes.portal, props.className)} />;
-};
+export const AlertDialogPortal = RadixAlertDialog.Portal;
 
 export const AlertDialogOverlay: typeof RadixAlertDialog.Overlay = React.forwardRef(
     function AlertDialogOverlay(props, forwardRef) {

--- a/src/components/context-menu/context-menu.st.css
+++ b/src/components/context-menu/context-menu.st.css
@@ -7,16 +7,14 @@
     -st-states: open('[data-state="open"]'), closed('[data-state="closed"]');
 }
 
-.portal {}
-
 @property st-global(--radix-context-menu-content-transform-origin);
 
 .content {
     -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-                left('[data-side="left"]'), right('[data-side="right"]'),
-                bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-                start('[data-align="start"]'), end('[data-align="end"]'),
-                center('[data-align="center"]');
+                 left('[data-side="left"]'), right('[data-side="right"]'),
+                 bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+                 start('[data-align="start"]'), end('[data-align="end"]'),
+                 center('[data-align="center"]');
 }
 
 .arrow {}
@@ -31,21 +29,21 @@
 
 .checkboxItem {
     -st-states: checked('[data-state="checked"]'),
-                unchecked('[data-state="unchecked"]'),
-                highlighted('[data-highlighted]'), disabled('[data-disabled]');
+                 unchecked('[data-state="unchecked"]'),
+                 highlighted('[data-highlighted]'), disabled('[data-disabled]');
 }
 
 .radioGroup {}
 
 .radioItem {
     -st-states: checked('[data-state="checked"]'),
-                unchecked('[data-state="unchecked"]'),
-                highlighted('[data-highlighted]'), disabled('[data-disabled]');
+                 unchecked('[data-state="unchecked"]'),
+                 highlighted('[data-highlighted]'), disabled('[data-disabled]');
 }
 
 .itemIndicator {
     -st-states: checked('[data-state="checked"]'),
-                unchecked('[data-state="unchecked"]');
+                 unchecked('[data-state="unchecked"]');
 }
 
 .separator {}
@@ -57,13 +55,13 @@
 
 .subTrigger {
     -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-                highlighted('[data-highlighted]'), disabled('[data-disabled]');
+                 highlighted('[data-highlighted]'), disabled('[data-disabled]');
 }
 
 .subContent {
     -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-                left('[data-side="left"]'), right('[data-side="right"]'),
-                bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-                start('[data-align="start"]'), end('[data-align="end"]'),
-                center('[data-align="center"]');
+                 left('[data-side="left"]'), right('[data-side="right"]'),
+                 bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+                 start('[data-align="start"]'), end('[data-align="end"]'),
+                 center('[data-align="center"]');
 }

--- a/src/components/context-menu/context-menu.st.css
+++ b/src/components/context-menu/context-menu.st.css
@@ -11,10 +11,10 @@
 
 .content {
     -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-                 left('[data-side="left"]'), right('[data-side="right"]'),
-                 bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-                 start('[data-align="start"]'), end('[data-align="end"]'),
-                 center('[data-align="center"]');
+                left('[data-side="left"]'), right('[data-side="right"]'),
+                bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+                start('[data-align="start"]'), end('[data-align="end"]'),
+                center('[data-align="center"]');
 }
 
 .arrow {}
@@ -29,21 +29,21 @@
 
 .checkboxItem {
     -st-states: checked('[data-state="checked"]'),
-                 unchecked('[data-state="unchecked"]'),
-                 highlighted('[data-highlighted]'), disabled('[data-disabled]');
+                unchecked('[data-state="unchecked"]'),
+                highlighted('[data-highlighted]'), disabled('[data-disabled]');
 }
 
 .radioGroup {}
 
 .radioItem {
     -st-states: checked('[data-state="checked"]'),
-                 unchecked('[data-state="unchecked"]'),
-                 highlighted('[data-highlighted]'), disabled('[data-disabled]');
+                unchecked('[data-state="unchecked"]'),
+                highlighted('[data-highlighted]'), disabled('[data-disabled]');
 }
 
 .itemIndicator {
     -st-states: checked('[data-state="checked"]'),
-                 unchecked('[data-state="unchecked"]');
+                unchecked('[data-state="unchecked"]');
 }
 
 .separator {}
@@ -55,13 +55,13 @@
 
 .subTrigger {
     -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-                 highlighted('[data-highlighted]'), disabled('[data-disabled]');
+                highlighted('[data-highlighted]'), disabled('[data-disabled]');
 }
 
 .subContent {
     -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-                 left('[data-side="left"]'), right('[data-side="right"]'),
-                 bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-                 start('[data-align="start"]'), end('[data-align="end"]'),
-                 center('[data-align="center"]');
+                left('[data-side="left"]'), right('[data-side="right"]'),
+                bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+                start('[data-align="start"]'), end('[data-align="end"]'),
+                center('[data-align="center"]');
 }

--- a/src/components/context-menu/context-menu.tsx
+++ b/src/components/context-menu/context-menu.tsx
@@ -18,9 +18,7 @@ export const ContextMenuTrigger: typeof RadixContextMenu.Trigger = React.forward
     }
 );
 
-export const ContextMenuPortal: React.FC<RadixContextMenu.ContextMenuPortalProps> = (props) => (
-    <RadixContextMenu.Portal {...props} className={st(classes.portal, props.className)} />
-);
+export const ContextMenuPortal = RadixContextMenu.Portal;
 
 export const ContextMenuContent: typeof RadixContextMenu.Content = React.forwardRef(
     function ContextMenuContent(props, forwardRef) {

--- a/src/components/dialog/dialog.st.css
+++ b/src/components/dialog/dialog.st.css
@@ -7,8 +7,6 @@
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]');
 }
 
-.portal {}
-
 .overlay {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]');
 }

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -17,9 +17,7 @@ export const DialogTrigger: typeof RadixDialog.Trigger = React.forwardRef(functi
     );
 });
 
-export const DialogPortal: React.FC<RadixDialog.DialogPortalProps> = (props) => (
-    <RadixDialog.Portal {...props} className={st(classes.portal, props.className)} />
-);
+export const DialogPortal = RadixDialog.Portal;
 
 export const DialogOverlay: typeof RadixDialog.Overlay = React.forwardRef(function DialogOverlay(
     props,

--- a/src/components/dropdown-menu/dropdown-menu.st.css
+++ b/src/components/dropdown-menu/dropdown-menu.st.css
@@ -12,20 +12,20 @@
 
 .content {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-               left('[data-side="left"]'), right('[data-side="right"]'),
-               bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-               start('[data-align="start"]'), end('[data-align="end"]'),
-               center('[data-align="center"]'),
-               vertical('[data-orientation="vertical"]'),
-               horizontal('[data-orientation="horizontal"]');
+              left('[data-side="left"]'), right('[data-side="right"]'),
+              bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+              start('[data-align="start"]'), end('[data-align="end"]'),
+              center('[data-align="center"]'),
+              vertical('[data-orientation="vertical"]'),
+              horizontal('[data-orientation="horizontal"]');
 }
 
 .arrow {}
 
 .item {
   -st-states: vertical('[data-orientation="vertical"]'),
-               horizontal('[data-orientation="horizontal"]'),
-               disabled('[data-disabled]'), highlighted('[data-highlighted]');
+              horizontal('[data-orientation="horizontal"]'),
+              disabled('[data-disabled]'), highlighted('[data-highlighted]');
 }
 
 .group {}
@@ -34,21 +34,21 @@
 
 .checkboxItem {
   -st-states: checked('[data-state="checked"]'),
-               unchecked('[data-state="unchecked"]'),
-               disabled('[data-disabled]'), highlighted('[data-highlighted]');
+              unchecked('[data-state="unchecked"]'),
+              disabled('[data-disabled]'), highlighted('[data-highlighted]');
 }
 
 .radioGroup {}
 
 .radioItem {
   -st-states: checked('[data-state="checked"]'),
-               unchecked('[data-state="unchecked"]'),
-               disabled('[data-disabled]'), highlighted('[data-highlighted]');
+              unchecked('[data-state="unchecked"]'),
+              disabled('[data-disabled]'), highlighted('[data-highlighted]');
 }
 
 .itemIndicator {
   -st-states: checked('[data-state="checked"]'),
-               unchecked('[data-state="unchecked"]');
+              unchecked('[data-state="unchecked"]');
 }
 
 .separator {}
@@ -60,15 +60,15 @@
 
 .subTrigger {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-               disabled('[data-disabled]'), highlighted('[data-highlighted]');
+              disabled('[data-disabled]'), highlighted('[data-highlighted]');
 }
 
 .subContent {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-               left('[data-side="left"]'), right('[data-side="right"]'),
-               bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-               start('[data-align="start"]'), end('[data-align="end"]'),
-               center('[data-align="center"]'),
-               vertical('[data-orientation="vertical"]'),
-               horizontal('[data-orientation="horizontal"]');
+              left('[data-side="left"]'), right('[data-side="right"]'),
+              bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+              start('[data-align="start"]'), end('[data-align="end"]'),
+              center('[data-align="center"]'),
+              vertical('[data-orientation="vertical"]'),
+              horizontal('[data-orientation="horizontal"]');
 }

--- a/src/components/dropdown-menu/dropdown-menu.st.css
+++ b/src/components/dropdown-menu/dropdown-menu.st.css
@@ -5,7 +5,7 @@
 
 .trigger {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-               disabled('[data-disabled]');
+              disabled('[data-disabled]');
 }
 
 @property st-global(--radix-hover-card-content-transform-origin);

--- a/src/components/dropdown-menu/dropdown-menu.st.css
+++ b/src/components/dropdown-menu/dropdown-menu.st.css
@@ -5,29 +5,27 @@
 
 .trigger {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-              disabled('[data-disabled]');
+               disabled('[data-disabled]');
 }
-
-.portal {}
 
 @property st-global(--radix-hover-card-content-transform-origin);
 
 .content {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-              left('[data-side="left"]'), right('[data-side="right"]'),
-              bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-              start('[data-align="start"]'), end('[data-align="end"]'),
-              center('[data-align="center"]'),
-              vertical('[data-orientation="vertical"]'),
-              horizontal('[data-orientation="horizontal"]');
+               left('[data-side="left"]'), right('[data-side="right"]'),
+               bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+               start('[data-align="start"]'), end('[data-align="end"]'),
+               center('[data-align="center"]'),
+               vertical('[data-orientation="vertical"]'),
+               horizontal('[data-orientation="horizontal"]');
 }
 
 .arrow {}
 
 .item {
   -st-states: vertical('[data-orientation="vertical"]'),
-              horizontal('[data-orientation="horizontal"]'),
-              disabled('[data-disabled]'), highlighted('[data-highlighted]');
+               horizontal('[data-orientation="horizontal"]'),
+               disabled('[data-disabled]'), highlighted('[data-highlighted]');
 }
 
 .group {}
@@ -36,21 +34,21 @@
 
 .checkboxItem {
   -st-states: checked('[data-state="checked"]'),
-              unchecked('[data-state="unchecked"]'),
-              disabled('[data-disabled]'), highlighted('[data-highlighted]');
+               unchecked('[data-state="unchecked"]'),
+               disabled('[data-disabled]'), highlighted('[data-highlighted]');
 }
 
 .radioGroup {}
 
 .radioItem {
   -st-states: checked('[data-state="checked"]'),
-              unchecked('[data-state="unchecked"]'),
-              disabled('[data-disabled]'), highlighted('[data-highlighted]');
+               unchecked('[data-state="unchecked"]'),
+               disabled('[data-disabled]'), highlighted('[data-highlighted]');
 }
 
 .itemIndicator {
   -st-states: checked('[data-state="checked"]'),
-              unchecked('[data-state="unchecked"]');
+               unchecked('[data-state="unchecked"]');
 }
 
 .separator {}
@@ -62,15 +60,15 @@
 
 .subTrigger {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-              disabled('[data-disabled]'), highlighted('[data-highlighted]');
+               disabled('[data-disabled]'), highlighted('[data-highlighted]');
 }
 
 .subContent {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-              left('[data-side="left"]'), right('[data-side="right"]'),
-              bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-              start('[data-align="start"]'), end('[data-align="end"]'),
-              center('[data-align="center"]'),
-              vertical('[data-orientation="vertical"]'),
-              horizontal('[data-orientation="horizontal"]');
+               left('[data-side="left"]'), right('[data-side="right"]'),
+               bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+               start('[data-align="start"]'), end('[data-align="end"]'),
+               center('[data-align="center"]'),
+               vertical('[data-orientation="vertical"]'),
+               horizontal('[data-orientation="horizontal"]');
 }

--- a/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/src/components/dropdown-menu/dropdown-menu.tsx
@@ -18,9 +18,7 @@ export const DropdownMenuTrigger: typeof RadixDropdownMenu.Trigger = React.forwa
     }
 );
 
-export const DropdownMenuPortal: React.FC<RadixDropdownMenu.DropdownMenuPortalProps> = (props) => (
-    <RadixDropdownMenu.Portal {...props} className={st(classes.portal, props.className)} />
-);
+export const DropdownMenuPortal = RadixDropdownMenu.Portal;
 
 export const DropdownMenuContent: typeof RadixDropdownMenu.Content = React.forwardRef(
     function DropdownMenuContent(props, forwardRef) {

--- a/src/components/hover-card/hover-card.st.css
+++ b/src/components/hover-card/hover-card.st.css
@@ -7,16 +7,14 @@
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]');
 }
 
-.portal {}
-
 @property st-global(--radix-dropdown-menu-content-transform-origin);
 
 .content {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-              left('[data-side="left"]'), right('[data-side="right"]'),
-              bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-              start('[data-align="start"]'), end('[data-align="end"]'),
-              center('[data-align="center"]');
+               left('[data-side="left"]'), right('[data-side="right"]'),
+               bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+               start('[data-align="start"]'), end('[data-align="end"]'),
+               center('[data-align="center"]');
 }
 
 .arrow {}

--- a/src/components/hover-card/hover-card.st.css
+++ b/src/components/hover-card/hover-card.st.css
@@ -11,10 +11,10 @@
 
 .content {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-               left('[data-side="left"]'), right('[data-side="right"]'),
-               bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-               start('[data-align="start"]'), end('[data-align="end"]'),
-               center('[data-align="center"]');
+              left('[data-side="left"]'), right('[data-side="right"]'),
+              bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+              start('[data-align="start"]'), end('[data-align="end"]'),
+              center('[data-align="center"]');
 }
 
 .arrow {}

--- a/src/components/hover-card/hover-card.tsx
+++ b/src/components/hover-card/hover-card.tsx
@@ -18,9 +18,7 @@ export const HoverCardTrigger: typeof RadixHoverCard.Trigger = React.forwardRef(
     }
 );
 
-export const HoverCardPortal: React.FC<RadixHoverCard.HoverCardPortalProps> = (props) => (
-    <RadixHoverCard.Portal {...props} className={st(classes.portal, props.className)} />
-);
+export const HoverCardPortal = RadixHoverCard.Portal;
 
 export const HoverCardContent: typeof RadixHoverCard.Content = React.forwardRef(
     function HoverCardContent(props, forwardRef) {

--- a/src/components/menubar/menubar.st.css
+++ b/src/components/menubar/menubar.st.css
@@ -11,8 +11,6 @@
     disabled('[data-disabled]');
 }
 
-.portal {}
-
 @property st-global(--radix-menubar-content-transform-origin);
 @property st-global(--radix-menubar-content-available-width);
 @property st-global(--radix-menubar-content-available-height);

--- a/src/components/menubar/menubar.tsx
+++ b/src/components/menubar/menubar.tsx
@@ -32,9 +32,7 @@ export const MenubarTrigger: typeof RadixMenubar.Trigger = React.forwardRef(func
     );
 });
 
-export const MenubarPortal: React.FC<RadixMenubar.MenubarPortalProps> = (props) => (
-    <RadixMenubar.Portal {...props} className={st(classes.portal, props.className)} />
-);
+export const MenubarPortal = RadixMenubar.Portal;
 
 export const MenubarContent: typeof RadixMenubar.Content = React.forwardRef(function MenubarPortal(
     props,

--- a/src/components/popover/popover.st.css
+++ b/src/components/popover/popover.st.css
@@ -13,10 +13,10 @@
 
 .content {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-               left('[data-side="left"]'), right('[data-side="right"]'),
-               bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-               start('[data-align="start"]'), end('[data-align="end"]'),
-               center('[data-align="center"]');
+              left('[data-side="left"]'), right('[data-side="right"]'),
+              bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+              start('[data-align="start"]'), end('[data-align="end"]'),
+              center('[data-align="center"]');
 }
 
 .arrow {}

--- a/src/components/popover/popover.st.css
+++ b/src/components/popover/popover.st.css
@@ -9,16 +9,14 @@
 
 .anchor {}
 
-.portal {}
-
 @property st-global(--radix-popover-content-transform-origin);
 
 .content {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-              left('[data-side="left"]'), right('[data-side="right"]'),
-              bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-              start('[data-align="start"]'), end('[data-align="end"]'),
-              center('[data-align="center"]');
+               left('[data-side="left"]'), right('[data-side="right"]'),
+               bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+               start('[data-align="start"]'), end('[data-align="end"]'),
+               center('[data-align="center"]');
 }
 
 .arrow {}

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -32,9 +32,7 @@ export const PopoverAnchor: typeof RadixPopover.Anchor = React.forwardRef(functi
     );
 });
 
-export const PopoverPortal: React.FC<RadixPopover.PopoverPortalProps> = (props) => (
-    <RadixPopover.Portal {...props} className={st(classes.portal, props.className)} />
-);
+export const PopoverPortal = RadixPopover.Portal;
 
 export const PopoverContent: typeof RadixPopover.Content = React.forwardRef(function PopoverContent(
     props,

--- a/src/components/select/select.st.css
+++ b/src/components/select/select.st.css
@@ -5,14 +5,12 @@
 
 .trigger {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-              disabled('[data-disabled]'), placeholder('[data-placeholder]');
+               disabled('[data-disabled]'), placeholder('[data-placeholder]');
 }
 
 .value {}
 
 .icon {}
-
-.portal {}
 
 .content {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]');
@@ -22,8 +20,8 @@
 
 .item {
   -st-states: checked('[data-state="checked"]'),
-              unchecked('[data-state="unchecked"]'),
-              highlighted('[data-highlighted]'), disabled('[data-disabled]');
+               unchecked('[data-state="unchecked"]'),
+               highlighted('[data-highlighted]'), disabled('[data-disabled]');
 }
 
 .itemText {}

--- a/src/components/select/select.st.css
+++ b/src/components/select/select.st.css
@@ -5,7 +5,7 @@
 
 .trigger {
   -st-states: open('[data-state="open"]'), closed('[data-state="closed"]'),
-               disabled('[data-disabled]'), placeholder('[data-placeholder]');
+              disabled('[data-disabled]'), placeholder('[data-placeholder]');
 }
 
 .value {}
@@ -20,8 +20,8 @@
 
 .item {
   -st-states: checked('[data-state="checked"]'),
-               unchecked('[data-state="unchecked"]'),
-               highlighted('[data-highlighted]'), disabled('[data-disabled]');
+              unchecked('[data-state="unchecked"]'),
+              highlighted('[data-highlighted]'), disabled('[data-disabled]');
 }
 
 .itemText {}

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -43,9 +43,7 @@ export const SelectIcon: typeof RadixSelect.Icon = React.forwardRef(function Sel
     );
 });
 
-export const SelectPortal: React.FC<RadixSelect.SelectPortalProps> = (props) => (
-    <RadixSelect.Portal {...props} className={st(classes.portal, props.className)} />
-);
+export const SelectPortal = RadixSelect.Portal;
 
 export const SelectContent: typeof RadixSelect.Content = React.forwardRef(function SelectContent(
     props,

--- a/src/components/tooltip/tooltip.st.css
+++ b/src/components/tooltip/tooltip.st.css
@@ -5,20 +5,20 @@
 
 .trigger {
   -st-states: closed('[data-state="closed"]'),
-               delayed-open('[data-state="delayed-open"]'),
-               instant-open('[data-state="instant-open"]');
+              delayed-open('[data-state="delayed-open"]'),
+              instant-open('[data-state="instant-open"]');
 }
 
 @property st-global(--radix-tooltip-content-transform-origin);
 
 .content {
   -st-states: closed('[data-state="closed"]'),
-               delayed-open('[data-state="delayed-open"]'),
-               instant-open('[data-state="instant-open"]'),
-               left('[data-side="left"]'), right('[data-side="right"]'),
-               bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-               start('[data-align="start"]'), end('[data-align="end"]'),
-               center('[data-align="center"]');
+              delayed-open('[data-state="delayed-open"]'),
+              instant-open('[data-state="instant-open"]'),
+              left('[data-side="left"]'), right('[data-side="right"]'),
+              bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+              start('[data-align="start"]'), end('[data-align="end"]'),
+              center('[data-align="center"]');
 }
 
 .arrow {}

--- a/src/components/tooltip/tooltip.st.css
+++ b/src/components/tooltip/tooltip.st.css
@@ -5,22 +5,20 @@
 
 .trigger {
   -st-states: closed('[data-state="closed"]'),
-              delayed-open('[data-state="delayed-open"]'),
-              instant-open('[data-state="instant-open"]');
+               delayed-open('[data-state="delayed-open"]'),
+               instant-open('[data-state="instant-open"]');
 }
-
-.portal {}
 
 @property st-global(--radix-tooltip-content-transform-origin);
 
 .content {
   -st-states: closed('[data-state="closed"]'),
-              delayed-open('[data-state="delayed-open"]'),
-              instant-open('[data-state="instant-open"]'),
-              left('[data-side="left"]'), right('[data-side="right"]'),
-              bottom('[data-side="bottom"]'), top('[data-side="top"]'),
-              start('[data-align="start"]'), end('[data-align="end"]'),
-              center('[data-align="center"]');
+               delayed-open('[data-state="delayed-open"]'),
+               instant-open('[data-state="instant-open"]'),
+               left('[data-side="left"]'), right('[data-side="right"]'),
+               bottom('[data-side="bottom"]'), top('[data-side="top"]'),
+               start('[data-align="start"]'), end('[data-align="end"]'),
+               center('[data-align="center"]');
 }
 
 .arrow {}

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -23,9 +23,7 @@ export const TooltipTrigger: typeof RadixTooltip.Trigger = React.forwardRef(func
     );
 });
 
-export const TooltipPortal: React.FC<RadixTooltip.TooltipPortalProps> = (props) => (
-    <RadixTooltip.Portal {...props} className={st(classes.portal, props.className)} />
-);
+export const TooltipPortal = RadixTooltip.Portal;
 
 export const TooltipContent: typeof RadixTooltip.Content = React.forwardRef(function TooltipContent(
     props,


### PR DESCRIPTION
This PR aligns with the [change made in radix-ui](https://github.com/radix-ui/primitives/pull/2178), where unnecessary props were eliminated from the portal. Consequently, we've removed the inaccessible portal parts and the className property from multiple portal components.

